### PR TITLE
Weatherman 2.4.1.2

### DIFF
--- a/stable/Weatherman/manifest.toml
+++ b/stable/Weatherman/manifest.toml
@@ -5,7 +5,7 @@
 # must be accessible (i.e. no `git` or `ssh` URLs, as the agent cannot clone those)
 repository = "https://github.com/NightmareXIV/Weatherman.git"
 # The commit to check out and build from the repository.
-commit = "39e34ffc3f2f5631d4a79d3b6015575b298308d2"
+commit = "1b8d067d220f4055259f3907bc48a21e9ee12602"
 # The people authorised to update this manifest (e.g. who can deploy updates). These are GitHub usernames.
 owners = [
     "Limiana"


### PR DESCRIPTION
- Fixed Orchestion plugin integration not working
- Fixed an issue where if songs with same title were present, it was impossible to select second and further
- Weather blacklist can now be configured to work either only in or only out of cutscenes
- An option to show current weather in server info bar was added